### PR TITLE
Fix yaml syntax to proper redirect regex with /

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -174,9 +174,9 @@ class Ros2bagFileserverCharm(CharmBase):
         middlewares = {
             f"juju-sidecar-trailing-slash-handler-{self.model.name}-{self.model.app.name}": {
                 "redirectRegex": {
-                    "regex": [f"^(.*)\\/{external_path}$"],
-                    "replacement": [f"/{external_path}/"],
-                    "permanent": True,
+                    "regex": f"^(.*)\\/{external_path}$",
+                    "replacement": f"/{external_path}/",
+                    "permanent": False,
                 }
             },
             f"juju-sidecar-noprefix-{self.model.name}-{self.model.app.name}": {

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -99,9 +99,9 @@ class TestCharm(unittest.TestCase):
                     },
                     "juju-sidecar-trailing-slash-handler-testmodel-ros2bag-fileserver": {
                         "redirectRegex": {
-                            "permanent": True,
-                            "regex": ["^(.*)\/testmodel-ros2bag-fileserver$"],  # noqa
-                            "replacement": ["/testmodel-ros2bag-fileserver/"],
+                            "permanent": False,
+                            "regex": "^(.*)\/testmodel-ros2bag-fileserver$",  # noqa
+                            "replacement": "/testmodel-ros2bag-fileserver/",
                         }
                     },
                 },


### PR DESCRIPTION
Fix Traefik configuration yaml syntax for redirectRegex, to correctly redirect url to url/