### PR TITLE
fix(ci): use juju 3.6 LTS channel

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,5 +14,7 @@ jobs:
   release:
     uses: canonical/observability/.github/workflows/charm-release.yaml@v0
     # secrets: inherit
+    with:
+      juju-channel: 3.6/stable
     secrets:
       CHARMHUB_TOKEN: ${{ secrets.CHARMHUB_TOKEN }}


### PR DESCRIPTION
Release CI is failing due to the juju channel: https://github.com/canonical/ros2bag-fileserver-k8s-operator/actions/runs/21673873419/job/62488752313
