### PR TITLE
[hermes-agent] Fix release workflow startup failure from missing permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,11 @@ on:
 
 jobs:
   release:
+    permissions:
+      actions: read
+      contents: write
+      issues: write
+      security-events: write
     uses: canonical/observability/.github/workflows/charm-release.yaml@v0
     # secrets: inherit
     with:


### PR DESCRIPTION
[hermes-agent]

## Summary
- add explicit `permissions` to the `release` job in `.github/workflows/release.yaml`
- align caller permissions with requirements of the updated `canonical/observability` reusable release workflow

## Root cause
The failing run `27814915353` exited as `startup_failure` before creating jobs. It started right after `canonical/observability/.github/workflows/charm-release.yaml@v0` advanced to commit `3414ea10e5fd0c10246c07937a3f621ff54cadc2`, which introduced explicit permission requirements in nested reusable jobs.

Our caller workflow did not declare matching job permissions, so workflow expansion/validation failed at startup.

## Validation
- local diff is minimal and limited to workflow permissions
- branch pushed; PR checks will validate end-to-end on GitHub Actions
