### PR TITLE
[hermes-agent] Fix startup failures in reusable workflow callers

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -56,6 +56,11 @@ jobs:
 
   pull-request:
     name: PR
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+      security-events: write
     uses: canonical/observability/.github/workflows/charm-pull-request.yaml@v0
     secrets: inherit
     with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,11 @@ on:
 
 jobs:
   release:
+    permissions:
+      actions: read
+      contents: write
+      issues: write
+      security-events: write
     uses: canonical/observability/.github/workflows/charm-release.yaml@v0
     # secrets: inherit
     with:


### PR DESCRIPTION
[hermes-agent]

## Summary
- add explicit `permissions` in `.github/workflows/release.yaml` for the reusable release workflow caller
- add explicit `permissions` in `.github/workflows/pull-request.yaml` for the reusable pull-request workflow caller

## Root cause
Both failing runs (`27814915353` on `Release Charm to Edge and Publish Libraries` and PR run `27826398098`) failed with `startup_failure` and no jobs created.

This started after `canonical/observability` workflow tag `v0` advanced to commit `3414ea10e5fd0c10246c07937a3f621ff54cadc2`, where reusable workflow callers now require explicit permissions to satisfy nested jobs.

The caller workflows in this repository did not define those permissions, so GitHub rejected workflow startup during validation/expansion.

## Validation
- diff only touches workflow caller permissions
- branch pushed; CI on this PR validates the fix
